### PR TITLE
chore: update ci repo and tag

### DIFF
--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -13,8 +13,8 @@ jobs:
       docker-file: api/Dockerfile
       context: api/        
       readme-file: ./README.md
-      docker-repo-name: menloltd/visual-thinker
-      tags: menloltd/visual-thinker:api-${{ github.sha }}
+      docker-repo-name: menloltd/visual-thinker-be
+      tags: menloltd/visual-thinker-be:dev-${{ github.sha }}
       build-args: |
-        GIT_COMMIT=menloltd/visual-thinker:api-${{ github.sha }}
+        GIT_COMMIT=menloltd/visual-thinker-be:dev-${{ github.sha }}
         GIT_COMMIT_MESSAGE=${{ github.event.head_commit.message }}

--- a/.github/workflows/deploy-playground.yaml
+++ b/.github/workflows/deploy-playground.yaml
@@ -13,8 +13,8 @@ jobs:
       docker-file: playground/Dockerfile
       context: playground/        
       readme-file: ./README.md
-      docker-repo-name: menloltd/visual-thinker
-      tags: menloltd/visual-thinker:playground-${{ github.sha }}
+      docker-repo-name: menloltd/visual-thinker-fe
+      tags: menloltd/visual-thinker-fe:dev-${{ github.sha }}
       build-args: |
-        GIT_COMMIT=menloltd/visual-thinker:playground-${{ github.sha }}
+        GIT_COMMIT=menloltd/visual-thinker-fe:dev-${{ github.sha }}
         GIT_COMMIT_MESSAGE=${{ github.event.head_commit.message }}

--- a/.github/workflows/quality-gate-api.yaml
+++ b/.github/workflows/quality-gate-api.yaml
@@ -14,5 +14,5 @@ jobs:
       context: api/
       is_push: false
       readme-file: ./README.md
-      docker-repo-name: menloltd/visual-thinker
-      tags: menloltd/visual-thinker:api-${{ github.sha }}
+      docker-repo-name: menloltd/visual-thinker-be
+      tags: menloltd/visual-thinker-be:${{ github.sha }}

--- a/.github/workflows/quality-gate-playground.yaml
+++ b/.github/workflows/quality-gate-playground.yaml
@@ -14,5 +14,5 @@ jobs:
       context: playground/
       is_push: false
       readme-file: ./README.md
-      docker-repo-name: menloltd/visual-thinker
-      tags: menloltd/visual-thinker:playground-${{ github.sha }}
+      docker-repo-name: menloltd/visual-thinker-fe
+      tags: menloltd/visual-thinker-fe:${{ github.sha }}


### PR DESCRIPTION
This pull request updates the Docker repository names and tags in several GitHub workflow files to reflect a more accurate naming convention. The changes ensure that the backend and frontend services are correctly tagged and pushed to their respective repositories.

Changes in GitHub workflow files:

* [`.github/workflows/deploy-api.yaml`](diffhunk://#diff-f55fee8985f6d62b4ff6effc73b4337bad5da9cbad0da46a25ce286b1e2bd3c3L16-R19): Updated `docker-repo-name` and `tags` to use `menloltd/visual-thinker-be` for the backend service.
* [`.github/workflows/deploy-playground.yaml`](diffhunk://#diff-9ada9d906b8fb7d822a6daa9dfea26ab32d9bf98efe5a90ab0b5740139a5f633L16-R19): Updated `docker-repo-name` and `tags` to use `menloltd/visual-thinker-fe` for the frontend service.
* [`.github/workflows/quality-gate-api.yaml`](diffhunk://#diff-771d1d8a817e21107a5c2a1100d5c54e250600e1a1952e533a5c8132ec4348dbL17-R18): Updated `docker-repo-name` and `tags` to use `menloltd/visual-thinker-be` for the backend quality gate.
* [`.github/workflows/quality-gate-playground.yaml`](diffhunk://#diff-df33b479db50d1af7bcc7b39cce2570695fe7b1ec1bdacd53b9cb55d99b7c112L17-R18): Updated `docker-repo-name` and `tags` to use `menloltd/visual-thinker-fe` for the frontend quality gate.