### PR TITLE
fix: add vllm path Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,9 +11,10 @@ FROM pytorch/pytorch:2.1.2-cuda12.1-cudnn8-runtime
 
 WORKDIR /app
 
-# Install vLLM directly in runtime stage
+# Install vLLM and add it to PATH
 RUN pip install --upgrade pip && \
-    pip install vllm==0.3.3 --no-cache-dir
+    pip install vllm==0.3.3 --no-cache-dir && \
+    ln -s /usr/local/bin/vllm /usr/bin/vllm
 
 # Copy required files
 COPY config.yml api_tokens.yml ./


### PR DESCRIPTION
This pull request includes a change to the `api/Dockerfile` to improve the installation and accessibility of the `vLLM` package.

* [`api/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L14-R17): Modified the installation process of `vLLM` to include a symbolic link, ensuring that `vLLM` is added to the system's `PATH` for easier access.