### PR TITLE
chore: export model name env

### DIFF
--- a/playground/src/app/api/chat/route.ts
+++ b/playground/src/app/api/chat/route.ts
@@ -5,13 +5,15 @@ export async function POST(req: Request) {
   // Make a request to OpenAI's API based on
   // a placeholder prompt
   const { messages } = await req.json();
-
+  const DEFAULT_MODEL = "jan-hq/AlphaMaze-v0.2-1.5B-GRPO-cp-600";
+  const modelName = process.env.MODEL_NAME || DEFAULT_MODEL;
+  
   const openai = createOpenAI({
     baseURL: process.env.API_URL,
     apiKey: "menlo",
   });
   const response = streamText({
-    model: openai("jan-hq/AlphaMaze-v0.2-1.5B-GRPO-cp-600"),
+    model: openai(modelName),
     temperature: 0.6,
     messages,
   });


### PR DESCRIPTION
This pull request introduces a change to the `POST` function in `playground/src/app/api/chat/route.ts` to make the model name configurable via an environment variable. This update allows for greater flexibility and easier updates to the model being used.

Key change:
* [`playground/src/app/api/chat/route.ts`](diffhunk://#diff-536cfbcd45117a059705b0dde7cd2dae970526b3e7b55535b208efde84e968cbR8-R16): Added a new constant `DEFAULT_MODEL` and modified the `model` parameter in the `streamText` function to use the `modelName` which defaults to `DEFAULT_MODEL` or can be set via the `MODEL_NAME` environment variable.